### PR TITLE
Heroku deployment URL support

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,10 +57,15 @@ async function waitForDeployment (options) {
         .filter(status => status.state === 'success')
       if (success) {
         core.info(`\tsuccess! ${JSON.stringify(success, null, 2)}`)
+        let url = success.target_url
+        const { payload = {} } = deployment
+        if (payload.web_url) {
+          url = payload.web_url
+        }
         return {
           deployment,
           status: success,
-          url: success.target_url
+          url
         }
       } else {
         core.info(`No statuses with state === "success": "${statuses.map(status => status.state).join('", "')}"`)


### PR DESCRIPTION
This updates the bit of JS that gets the deployment _status's_ `target_url` to look for the deployment object's `payload.web_url` if present. I guess that's where Heroku puts the actual deployment URL, because the status's `target_url` is Heroku build page. 🤷 